### PR TITLE
feat(cli): diplomat-gate validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-<!-- Collect changes for the next version here. -->
+### Added
+
+- `diplomat-gate validate <gate.yaml>` CLI subcommand — validates a gate.yaml
+  file without instantiating a Gate or executing any policies. Reports errors
+  (unknown policy ids, type mismatches, bad severity/on_fail values) and
+  warnings (unknown fields with difflib suggestions, empty domains, default
+  critical fields). Exit 0 if valid, 1 if errors, 2 if I/O error.
+- `src/diplomat_gate/validation.py` — pure validation module with stable JSON
+  output schema (`format_version: "1"`). Types: `Issue`, `ValidationReport`.
+  Public API: `validate_config()`, `report_to_dict()`, `format_report_text()`.
+- `iter_registered_policies()` in `diplomat_gate.policies.loader` — returns a
+  copy of the internal policy registry for read-only inspection.
+- `tests/test_validation.py` — unit tests for the validation module.
+- `tests/test_cli_validate.py` — integration tests (`@pytest.mark.integration`)
+  for the `diplomat-gate validate` CLI command.
+- `tests/fixtures/validation/` — 13 YAML fixtures covering valid configs,
+  error cases, and warning cases.
+- `examples/09_validate_in_ci.py` — demonstrates programmatic use of
+  `validate_config()` in a CI script.
+- `docs/cli.md` — full CLI reference for `validate`, `audit`, and `review`.
+- `scripts/validate_release.py` updated: added steps 10bis (validate --help)
+  and 10ter (validate gate.yaml.example); renumbered all steps to X/13.
 
 ## [0.3.0] — 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,24 @@ charge(amount=50_000, customer_id="cus_123")       # STOP    -> raises Blocked
 - **REVIEW**: raises `NeedsReview`; if `review_queue` is enabled, the
   call is also persisted for an operator to approve/reject.
 
+## Validate your gate.yaml
+
+Catch typos and misconfigured policies before deployment:
+
+```bash
+diplomat-gate validate gate.yaml
+# OK: 8 policies loaded, 0 errors, 0 warnings
+```
+
+Use `--json` for CI integration:
+
+```bash
+diplomat-gate validate gate.yaml --json --output report.json --quiet
+echo $?  # 0 if valid, 1 if errors, 2 if I/O error
+```
+
+See [docs/cli.md](docs/cli.md) for full flag reference and the JSON schema.
+
 ## Audit trail
 
 Every verdict is recorded in an append-only SQLite log with a SHA-256

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,182 @@
+# diplomat-gate CLI reference
+
+## Global flags
+
+```
+diplomat-gate [--no-color] <command> ...
+```
+
+| Flag | Description |
+|------|-------------|
+| `--no-color` | Disable ANSI colour codes in output. Must appear **before** the subcommand. |
+
+---
+
+## `validate` — validate a gate.yaml file
+
+```
+diplomat-gate [--no-color] validate <config_path> [--json] [--output FILE] [--quiet]
+```
+
+Inspect a `gate.yaml` file without instantiating a Gate or executing any policies.
+Returns a structured report listing errors and warnings.
+
+### Arguments
+
+| Argument / Flag | Description |
+|-----------------|-------------|
+| `config_path` | Path to the `gate.yaml` file to validate. |
+| `--json` | Emit machine-readable JSON on stdout instead of human text. |
+| `--output FILE` | Write the JSON report to `FILE`. A short summary still goes to stdout unless `--quiet` is set. |
+| `--quiet` | Suppress all stdout output. Exit code is preserved. |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No errors (warnings allowed). |
+| `1` | One or more validation errors found. |
+| `2` | I/O error (file not found, not readable), YAML parse error, or PyYAML not installed. |
+
+### Examples
+
+```bash
+# Basic validation — human-readable output
+diplomat-gate validate gate.yaml
+# OK: 8 policies loaded, 0 errors, 0 warnings
+
+# With warnings
+diplomat-gate validate config-with-typo.yaml
+# OK with warnings: 2 policies loaded, 0 errors, 1 warning(s)
+#   warning  payment[0].max_amout  unknown_field  Unknown field 'max_amout'. Did you mean 'max_amount'?
+
+# JSON output
+diplomat-gate validate gate.yaml --json
+# {"ok": true, "format_version": "1", "config_path": "gate.yaml", ...}
+
+# CI integration — write report file, suppress stdout, check exit code
+diplomat-gate validate gate.yaml --output report.json --quiet
+echo $?  # 0 if valid, 1 if errors, 2 if I/O error
+
+# No colour (e.g. in log files)
+diplomat-gate --no-color validate gate.yaml
+```
+
+### JSON output schema
+
+```json
+{
+  "ok": true,
+  "format_version": "1",
+  "config_path": "gate.yaml",
+  "policies_loaded": [
+    "email.business_hours",
+    "email.content_scan",
+    "email.domain_blocklist",
+    "email.rate_limit",
+    "payment.amount_limit",
+    "payment.duplicate_detection",
+    "payment.recipient_blocklist",
+    "payment.velocity"
+  ],
+  "errors": [],
+  "warnings": []
+}
+```
+
+Key order is stable across runs (diffable in CI artifacts). `policies_loaded` is sorted
+alphabetically. `errors` and `warnings` are sorted by `(path, code)`.
+
+Each issue has the following fields:
+
+```json
+{
+  "path": "payment[0].max_amount",
+  "code": "type_mismatch",
+  "message": "Field 'max_amount' expected float, got str ('ten thousand')",
+  "severity": "error"
+}
+```
+
+### Validation rules
+
+**Errors** (exit 1):
+
+| Code | Condition |
+|------|-----------|
+| `missing_id` | Policy entry has no `id` field, or `id` is not a string. |
+| `unknown_policy` | `id` references a policy not registered in the built-in registry. |
+| `bad_severity` | `severity` is not one of `critical`, `high`, `medium`, `low`. |
+| `bad_on_fail` | `on_fail` is not one of `STOP`, `REVIEW`. |
+| `bad_enabled` | `enabled` is not a bool. |
+| `type_mismatch` | A policy-specific field has an incompatible type. |
+| `audit_bad_type` | `audit.enabled` is not a bool, or `audit.path` is not a string. |
+| `review_queue_bad_type` | `review_queue.enabled` is not a bool, or `review_queue.path` is not a string. |
+| `bad_top_level_type` | A domain section (`payment`, `email`, `policies`) is not a list. |
+
+**Warnings** (exit 0, but reported):
+
+| Code | Condition |
+|------|-----------|
+| `unknown_field` | Unrecognised field on a policy entry (typo). Includes a `Did you mean?` suggestion via difflib. |
+| `unknown_audit_field` | Unrecognised field in the `audit:` section. |
+| `unknown_review_queue_field` | Unrecognised field in the `review_queue:` section. |
+| `empty_domain` | `payment: []` or `email: []` — empty list is legal but likely unintentional. |
+| `no_policies` | No policies loaded at all. |
+| `default_critical_field` | A critical policy field (`max_amount`, `max_daily`, `blocked`) is not set and will use its default value. |
+
+---
+
+## `audit` — audit log operations
+
+### `audit verify`
+
+```
+diplomat-gate audit verify --db <path>
+```
+
+Verify the SHA-256 hash chain of the audit log database.
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Chain is valid. |
+| `1` | Chain is invalid (tamper detected). |
+| `2` | I/O or database error. |
+
+### `audit rebuild-chain`
+
+```
+diplomat-gate audit rebuild-chain --db <path>
+```
+
+Recompute the sequence, previous hash, and record hash for every row.
+Use with caution — this overwrites existing hashes.
+
+---
+
+## `review` — review queue operations
+
+### `review list`
+
+```
+diplomat-gate review list --db <path> [--status pending|approved|rejected|expired|all] [--limit N] [--json]
+```
+
+List items in the review queue. Default status filter: `pending`.
+
+### `review show`
+
+```
+diplomat-gate review show --db <path> --id <item_id>
+```
+
+Display full details of a single review item.
+
+### `review approve` / `review reject`
+
+```
+diplomat-gate review approve --db <path> --id <item_id> --reviewer <name> [--note ...]
+diplomat-gate review reject  --db <path> --id <item_id> --reviewer <name> [--note ...]
+```
+
+Approve or reject a pending review item and record the decision.

--- a/examples/09_validate_in_ci.py
+++ b/examples/09_validate_in_ci.py
@@ -1,0 +1,50 @@
+"""09 — validate gate.yaml programmatically (CI usage).
+
+Demonstrates using ``validate_config()`` directly in a script to fail fast
+when a gate.yaml has errors, before any runtime evaluation occurs.
+
+Run::
+
+    python examples/09_validate_in_ci.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from diplomat_gate.validation import format_report_text, validate_config
+
+# Locate gate.yaml.example relative to this file, whether the script is run
+# from the repo root or from inside the examples/ directory.
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parent if (_HERE.parent / "gate.yaml.example").exists() else _HERE
+GATE_YAML = _REPO / "gate.yaml.example"
+
+
+def main() -> int:
+    print(f"Validating: {GATE_YAML}")
+
+    try:
+        report = validate_config(str(GATE_YAML))
+    except FileNotFoundError:
+        print(f"ERROR: file not found: {GATE_YAML}", file=sys.stderr)
+        return 2
+    except (ValueError, ImportError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_report_text(report, use_color=False))
+
+    if report.ok:
+        print(f"\nPolicies loaded: {', '.join(report.policies_loaded)}")
+        return 0
+
+    print(
+        f"\n{len(report.errors)} error(s) found — fix gate.yaml before deploying.", file=sys.stderr
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Release validation gate — 11 checks, stop at first failure.
+"""Release validation gate — 13 steps, stop at first failure.
 
 Usage:
     python scripts/validate_release.py
@@ -100,7 +100,7 @@ def main() -> None:
         venv = tmp_path / "venv"
         r1 = _run([PYTHON, "-m", "venv", str(venv)])
         if r1.returncode != 0:
-            print("  ✗ FAIL  [8/11] venv creation failed")
+            print("  ✗ FAIL  [8/13] venv creation failed")
             sys.exit(1)
         venv_python = venv / ("Scripts" if sys.platform == "win32" else "bin") / "python"
         r2 = _run([str(venv_python), "-m", "pip", "install", str(wheel), "--quiet"])

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -50,10 +50,10 @@ def main() -> None:
     print(f"\n  diplomat-gate release validation\n  {'─' * 40}")
 
     steps: list[tuple[str, list[str]]] = [
-        ("1/11 ruff check", [PYTHON, "-m", "ruff", "check", "."]),
-        ("2/11 ruff format", [PYTHON, "-m", "ruff", "format", "--check", "."]),
+        ("1/13 ruff check", [PYTHON, "-m", "ruff", "check", "."]),
+        ("2/13 ruff format", [PYTHON, "-m", "ruff", "format", "--check", "."]),
         (
-            "3/11 pytest --cov",
+            "3/13 pytest --cov",
             [
                 PYTHON,
                 "-m",
@@ -65,11 +65,11 @@ def main() -> None:
             ],
         ),
         (
-            "4/11 pytest integration",
+            "4/13 pytest integration",
             [PYTHON, "-m", "pytest", "-m", "integration", "-q", "--tb=short"],
         ),
         (
-            "5/11 benchmarks p95<5ms",
+            "5/13 benchmarks p95<5ms",
             [
                 PYTHON,
                 "benchmarks/run.py",
@@ -79,8 +79,8 @@ def main() -> None:
                 "5.0",
             ],
         ),
-        ("6/11 build sdist+wheel", [PYTHON, "-m", "build"]),
-        ("7/11 twine check", [PYTHON, "-m", "twine", "check", "dist/*"]),
+        ("6/13 build sdist+wheel", [PYTHON, "-m", "build"]),
+        ("7/13 twine check", [PYTHON, "-m", "twine", "check", "dist/*"]),
     ]
 
     for step, cmd in steps:
@@ -89,10 +89,10 @@ def main() -> None:
 
     # Step 8 — fresh venv smoke install
     print(f"  {'─' * 40}")
-    print("  [8/11 fresh-venv smoke install]", flush=True)
+    print("  [8/13 fresh-venv smoke install]", flush=True)
     dist_wheels = sorted(REPO.glob("dist/*.whl"))
     if not dist_wheels:
-        print("  ✗ FAIL  [8/11] no wheel found in dist/")
+        print("  ✗ FAIL  [8/13] no wheel found in dist/")
         sys.exit(1)
     wheel = dist_wheels[-1]
     with tempfile.TemporaryDirectory() as tmp:
@@ -105,34 +105,45 @@ def main() -> None:
         venv_python = venv / ("Scripts" if sys.platform == "win32" else "bin") / "python"
         r2 = _run([str(venv_python), "-m", "pip", "install", str(wheel), "--quiet"])
         if r2.returncode != 0:
-            print("  ✗ FAIL  [8/11] pip install failed")
+            print("  ✗ FAIL  [8/13] pip install failed")
             lines = (r2.stderr or r2.stdout or "").splitlines()[:3]
             for ln in lines:
                 print(f"         {ln}")
             sys.exit(1)
-        print("  ✓ PASS  [8/11 fresh-venv smoke install]")
+        print("  ✓ PASS  [8/13 fresh-venv smoke install]")
 
         # Step 9 — diplomat-gate --help
         venv_bin = venv / ("Scripts" if sys.platform == "win32" else "bin")
         diplomat_cmd = venv_bin / (
             "diplomat-gate.exe" if sys.platform == "win32" else "diplomat-gate"
         )
-        if not _check("9/11 diplomat-gate --help", [str(diplomat_cmd), "--help"]):
+        if not _check("9/13 diplomat-gate --help", [str(diplomat_cmd), "--help"]):
             sys.exit(1)
 
         # Step 10 — audit verify --help
         if not _check(
-            "10/11 audit verify --help", [str(diplomat_cmd), "audit", "verify", "--help"]
+            "10/13 audit verify --help", [str(diplomat_cmd), "audit", "verify", "--help"]
+        ):
+            sys.exit(1)
+
+        # Step 10bis — validate --help
+        if not _check("10bis/13 validate --help", [str(diplomat_cmd), "validate", "--help"]):
+            sys.exit(1)
+
+        # Step 10ter — validate gate.yaml.example
+        if not _check(
+            "10ter/13 validate gate.yaml.example",
+            [str(diplomat_cmd), "validate", str(REPO / "gate.yaml.example")],
         ):
             sys.exit(1)
 
     # Step 11 — demo --ci
     demo_path = REPO / "demos" / "openclaw" / "run.py"
     if demo_path.exists():
-        if not _check("11/11 demo --ci", [PYTHON, str(demo_path), "--ci"]):
+        if not _check("11/13 demo --ci", [PYTHON, str(demo_path), "--ci"]):
             sys.exit(1)
     else:
-        print("  ⚠ SKIP  [11/11 demo --ci] demos/openclaw/run.py not yet created (Phase 2)")
+        print("  ⚠ SKIP  [11/13 demo --ci] demos/openclaw/run.py not yet created (Phase 2)")
 
     print(f"\n  {'─' * 40}")
     print("  All checks passed. Ready to release.\n")

--- a/src/diplomat_gate/cli.py
+++ b/src/diplomat_gate/cli.py
@@ -1,6 +1,6 @@
 """Command-line interface for diplomat-gate.
 
-Currently exposes ``audit`` and ``review`` subcommands:
+Currently exposes ``audit``, ``review``, and ``validate`` subcommands:
 
 * ``diplomat-gate audit verify --db <path>``
 * ``diplomat-gate audit rebuild-chain --db <path>``
@@ -8,10 +8,12 @@ Currently exposes ``audit`` and ``review`` subcommands:
 * ``diplomat-gate review show --db <path> --id <item_id>``
 * ``diplomat-gate review approve --db <path> --id <item_id> --reviewer <name> [--note ...]``
 * ``diplomat-gate review reject --db <path> --id <item_id> --reviewer <name> [--note ...]``
+* ``diplomat-gate [--no-color] validate <config_path> [--json] [--output FILE] [--quiet]``
 
 Exit codes:
     0 — operation succeeded
-    1 — chain is invalid (audit verify only) or item not found (review)
+    1 — chain is invalid (audit verify only), item not found (review),
+        or validation errors present (validate)
     2 — usage / IO error
 """
 
@@ -96,6 +98,25 @@ def _build_parser() -> argparse.ArgumentParser:
     rr.add_argument("--reviewer", required=True)
     rr.add_argument("--note", default="")
 
+    val = sub.add_parser("validate", help="Validate a gate.yaml configuration file.")
+    val.add_argument("config_path", help="Path to the gate.yaml file to validate.")
+    val.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON on stdout instead of human text.",
+    )
+    val.add_argument(
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Write the JSON report to FILE (a short summary still goes to stdout).",
+    )
+    val.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress stdout. Exit code is preserved.",
+    )
+
     return parser
 
 
@@ -152,6 +173,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         finally:
             queue.close()
 
+    if args.cmd == "validate":
+        return _handle_validate(args, use_color=use_color)
+
     parser.print_help(sys.stderr)
     return 2
 
@@ -192,6 +216,38 @@ def _handle_review(args, queue: ReviewQueue) -> int:
         return 0
 
     return 2
+
+
+def _handle_validate(args, *, use_color: bool) -> int:
+    from .validation import (  # noqa: PLC0415
+        format_report_text,
+        report_to_dict,
+        validate_config,
+    )
+
+    try:
+        report = validate_config(args.config_path)
+    except FileNotFoundError:
+        print(f"error: file not found: {args.config_path}", file=sys.stderr)
+        return 2
+    except ImportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except (ValueError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report_to_dict(report), f, indent=2, sort_keys=False)
+
+    if not args.quiet:
+        if args.json:
+            print(json.dumps(report_to_dict(report), indent=2, sort_keys=False))
+        else:
+            print(format_report_text(report, use_color=use_color))
+
+    return 0 if report.ok else 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/diplomat_gate/policies/__init__.py
+++ b/src/diplomat_gate/policies/__init__.py
@@ -5,7 +5,7 @@ from .emails import (
     DomainBlocklistPolicy,
     EmailRateLimitPolicy,
 )
-from .loader import load_from_dict, load_from_yaml
+from .loader import iter_registered_policies, load_from_dict, load_from_yaml
 from .payments import (
     AmountLimitPolicy,
     DailyLimitPolicy,
@@ -27,4 +27,5 @@ __all__ = [
     "ContentScanPolicy",
     "load_from_dict",
     "load_from_yaml",
+    "iter_registered_policies",
 ]

--- a/src/diplomat_gate/policies/loader.py
+++ b/src/diplomat_gate/policies/loader.py
@@ -79,3 +79,12 @@ def load_from_yaml(path: str) -> list[Policy]:
     with open(path) as f:
         config = yaml.safe_load(f)
     return load_from_dict(config)
+
+
+def iter_registered_policies() -> dict[str, type[Policy]]:
+    """Return a copy of the policy registry.
+
+    Read-only — mutations on the returned dict have no effect on the
+    internal registry. Used by ``diplomat_gate.validation``.
+    """
+    return dict(_POLICY_MAP)

--- a/src/diplomat_gate/validation.py
+++ b/src/diplomat_gate/validation.py
@@ -649,13 +649,10 @@ def format_report_text(report: ValidationReport, *, use_color: bool) -> str:
     n_warn = len(report.warnings)
 
     if not report.ok:
-        header = (
-            f"{red}INVALID{reset}: {n_pol} policies loaded, {n_err} error(s), {n_warn} warning(s)"
-        )
+        header = f"{red}INVALID{reset}: {n_pol} policies loaded, {n_err} errors, {n_warn} warnings"
     elif n_warn > 0:
         header = (
-            f"{yellow}OK with warnings{reset}: {n_pol} policies loaded, "
-            f"0 errors, {n_warn} warning(s)"
+            f"{yellow}OK with warnings{reset}: {n_pol} policies loaded, 0 errors, {n_warn} warnings"
         )
     else:
         header = f"{green}OK{reset}: {n_pol} policies loaded, 0 errors, 0 warnings"

--- a/src/diplomat_gate/validation.py
+++ b/src/diplomat_gate/validation.py
@@ -1,0 +1,670 @@
+"""Validate gate.yaml configuration files.
+
+Pure, side-effect-free inspection of a configuration file. Does not
+instantiate a Gate. Does not perform any I/O beyond reading the YAML file.
+
+Used by:
+    - The `diplomat-gate validate` CLI command.
+    - The (future) `Diplomat-ai/gate-check-action` GitHub Action.
+    - The (future) pre-commit hook.
+
+Output format is stable across versions (see ``ValidationReport.format_version``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import difflib
+from dataclasses import dataclass
+from typing import Any, get_args, get_origin, get_type_hints
+
+from .policies.loader import iter_registered_policies
+
+# ── Public constants ───────────────────────────────────────────────────────────
+
+#: Schema version of the JSON output. Bump on breaking changes.
+FORMAT_VERSION = "1"
+
+#: Severity values accepted on policy entries.
+ALLOWED_SEVERITIES = ("critical", "high", "medium", "low")
+
+#: on_fail values accepted on policy entries.
+ALLOWED_ON_FAIL = ("STOP", "REVIEW")
+
+#: Common fields that exist on every policy (declared by ``Policy`` base class).
+_COMMON_POLICY_FIELDS = frozenset({"id", "name", "domain", "severity", "on_fail", "enabled"})
+
+#: Fields allowed in the top-level ``audit:`` section.
+_ALLOWED_AUDIT_FIELDS = frozenset({"enabled", "path"})
+
+#: Fields allowed in the top-level ``review_queue:`` section.
+_ALLOWED_REVIEW_QUEUE_FIELDS = frozenset({"enabled", "path", "ttl_seconds"})
+
+#: Top-level keys that are silently accepted (not policy domain lists).
+_KNOWN_TOP_LEVEL_KEYS = frozenset(
+    {"payment", "email", "policies", "audit", "review_queue", "version"}
+)
+
+#: Policies for which leaving the critical field at its default is suspicious.
+_CRITICAL_FIELDS_BY_POLICY: dict[str, str] = {
+    "payment.amount_limit": "max_amount",
+    "payment.daily_limit": "max_daily",
+    "payment.recipient_blocklist": "blocked",
+    "email.domain_blocklist": "blocked",
+}
+
+#: Base Policy dataclass field names — excluded from "specific fields" lookup.
+_BASE_POLICY_FIELD_NAMES = frozenset(
+    {"policy_id", "name", "domain", "severity", "on_fail", "enabled", "config"}
+)
+
+
+# ── Public types ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Issue:
+    """A single validation finding (error or warning)."""
+
+    path: str  # e.g. "payment[0].max_amount" or "audit.path"
+    code: str  # e.g. "unknown_policy", "type_mismatch"
+    message: str  # human-readable, English, no trailing period
+    severity: str  # "error" | "warning"
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Outcome of a validate_config() call."""
+
+    ok: bool  # True iff len(errors) == 0
+    errors: tuple[Issue, ...]  # sorted by (path, code)
+    warnings: tuple[Issue, ...]  # sorted by (path, code)
+    policies_loaded: tuple[str, ...]  # sorted alphabetically
+    config_path: str
+    format_version: str = FORMAT_VERSION
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+
+def _suggest(name: str, candidates: list[str]) -> str | None:
+    matches = difflib.get_close_matches(name, candidates, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+def _type_name(t: type) -> str:
+    """Return a human-readable name for a type annotation."""
+    origin = get_origin(t)
+    if origin is None:
+        return getattr(t, "__name__", repr(t))
+    args = get_args(t)
+    if origin is list:
+        inner = _type_name(args[0]) if args else "?"
+        return f"list[{inner}]"
+    if origin is dict:
+        k = _type_name(args[0]) if args else "?"
+        v = _type_name(args[1]) if len(args) > 1 else "?"
+        return f"dict[{k}, {v}]"
+    return repr(t)
+
+
+def _check_type(value: Any, expected: type) -> bool:
+    """Return True if ``value`` is compatible with ``expected``."""
+    origin = get_origin(expected)
+    if origin is None:
+        # bool is a subclass of int in Python — reject it explicitly for int/float.
+        if expected is int:
+            return isinstance(value, int) and not isinstance(value, bool)
+        if expected is float:
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if expected is bool:
+            return isinstance(value, bool)
+        # typing.Any — accept anything.
+        try:
+            from typing import Any as _Any  # noqa: PLC0415
+
+            if expected is _Any:
+                return True
+        except ImportError:
+            pass
+        try:
+            return isinstance(value, expected)
+        except TypeError:
+            return True  # exotic type — degrade gracefully
+    if origin is list:
+        if not isinstance(value, list):
+            return False
+        args = get_args(expected)
+        if not args:
+            return True
+        (inner,) = args
+        return all(_check_type(item, inner) for item in value)
+    if origin is dict:
+        if not isinstance(value, dict):
+            return False
+        args = get_args(expected)
+        if not args or len(args) < 2:
+            return True
+        k_type, v_type = args
+        return all(_check_type(k, k_type) and _check_type(v, v_type) for k, v in value.items())
+    # Fallback for unknown generic origins — accept.
+    return True
+
+
+def _get_specific_fields(cls: type) -> dict[str, type]:
+    """Return {yaml_field_name: expected_type} for fields specific to this policy class."""
+    try:
+        hints = get_type_hints(cls)
+    except Exception:  # noqa: BLE001
+        return {}
+    return {name: typ for name, typ in hints.items() if name not in _BASE_POLICY_FIELD_NAMES}
+
+
+def _get_known_yaml_fields(cls: type) -> frozenset[str]:
+    """Return the full set of valid YAML keys for a policy class."""
+    specific = _get_specific_fields(cls)
+    return _COMMON_POLICY_FIELDS | frozenset(specific.keys())
+
+
+def _get_field_default(cls: type, field_name: str) -> Any:
+    """Return the default value of a dataclass field, or ``dataclasses.MISSING``."""
+    try:
+        for f in dataclasses.fields(cls):  # type: ignore[arg-type]
+            if f.name == field_name:
+                if f.default is not dataclasses.MISSING:
+                    return f.default
+                if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                    return f.default_factory()
+                return dataclasses.MISSING
+    except Exception:  # noqa: BLE001
+        pass
+    return dataclasses.MISSING
+
+
+# ── Section validators ─────────────────────────────────────────────────────────
+
+
+def _validate_audit_section(
+    audit: Any,
+    errors: list[Issue],
+    warnings: list[Issue],
+) -> None:
+    if audit is None:
+        return
+    if not isinstance(audit, dict):
+        errors.append(
+            Issue(
+                path="audit",
+                code="bad_top_level_type",
+                message=f"'audit' must be a mapping, got {type(audit).__name__}",
+                severity="error",
+            )
+        )
+        return
+    for key in audit:
+        if key not in _ALLOWED_AUDIT_FIELDS:
+            suggestion = _suggest(key, list(_ALLOWED_AUDIT_FIELDS))
+            msg = f"Unknown field 'audit.{key}'"
+            if suggestion:
+                msg += f". Did you mean '{suggestion}'?"
+            warnings.append(
+                Issue(
+                    path=f"audit.{key}", code="unknown_audit_field", message=msg, severity="warning"
+                )
+            )
+    if "enabled" in audit and not isinstance(audit["enabled"], bool):
+        errors.append(
+            Issue(
+                path="audit.enabled",
+                code="audit_bad_type",
+                message=f"'audit.enabled' must be a bool, got {type(audit['enabled']).__name__}",
+                severity="error",
+            )
+        )
+    if "path" in audit and not isinstance(audit["path"], str):
+        errors.append(
+            Issue(
+                path="audit.path",
+                code="audit_bad_type",
+                message=f"'audit.path' must be a string, got {type(audit['path']).__name__}",
+                severity="error",
+            )
+        )
+
+
+def _validate_review_queue_section(
+    rq: Any,
+    errors: list[Issue],
+    warnings: list[Issue],
+) -> None:
+    if rq is None:
+        return
+    if not isinstance(rq, dict):
+        errors.append(
+            Issue(
+                path="review_queue",
+                code="bad_top_level_type",
+                message=f"'review_queue' must be a mapping, got {type(rq).__name__}",
+                severity="error",
+            )
+        )
+        return
+    for key in rq:
+        if key not in _ALLOWED_REVIEW_QUEUE_FIELDS:
+            suggestion = _suggest(key, list(_ALLOWED_REVIEW_QUEUE_FIELDS))
+            msg = f"Unknown field 'review_queue.{key}'"
+            if suggestion:
+                msg += f". Did you mean '{suggestion}'?"
+            warnings.append(
+                Issue(
+                    path=f"review_queue.{key}",
+                    code="unknown_review_queue_field",
+                    message=msg,
+                    severity="warning",
+                )
+            )
+    if "enabled" in rq and not isinstance(rq["enabled"], bool):
+        errors.append(
+            Issue(
+                path="review_queue.enabled",
+                code="review_queue_bad_type",
+                message=f"'review_queue.enabled' must be a bool, got {type(rq['enabled']).__name__}",
+                severity="error",
+            )
+        )
+    if "path" in rq and not isinstance(rq["path"], str):
+        errors.append(
+            Issue(
+                path="review_queue.path",
+                code="review_queue_bad_type",
+                message=f"'review_queue.path' must be a string, got {type(rq['path']).__name__}",
+                severity="error",
+            )
+        )
+
+
+def _validate_policy_entry(
+    entry: Any,
+    section_prefix: str,
+    idx: int,
+    registry: dict[str, type],
+    errors: list[Issue],
+    warnings: list[Issue],
+    policies_loaded: list[str],
+) -> None:
+    base_path = f"{section_prefix}[{idx}]"
+
+    if not isinstance(entry, dict):
+        errors.append(
+            Issue(
+                path=base_path,
+                code="bad_top_level_type",
+                message=f"Policy entry must be a mapping, got {type(entry).__name__}",
+                severity="error",
+            )
+        )
+        return
+
+    raw_id = entry.get("id")
+    if raw_id is None or not isinstance(raw_id, str):
+        errors.append(
+            Issue(
+                path=base_path,
+                code="missing_id",
+                message=(
+                    "Policy entry missing required 'id' field"
+                    if raw_id is None
+                    else f"'id' must be a string, got {type(raw_id).__name__}"
+                ),
+                severity="error",
+            )
+        )
+        return  # Cannot proceed without a valid id.
+
+    policy_id = raw_id
+    id_path = f"{section_prefix}[{idx}].id"
+
+    if policy_id not in registry:
+        suggestion = _suggest(policy_id, list(registry.keys()))
+        msg = f"Unknown policy id '{policy_id}'"
+        if suggestion:
+            msg += f". Did you mean '{suggestion}'?"
+        errors.append(Issue(path=id_path, code="unknown_policy", message=msg, severity="error"))
+        return  # Cannot validate fields without knowing the class.
+
+    cls = registry[policy_id]
+    has_error = False
+
+    # Common field checks.
+    if "severity" in entry:
+        sev = entry["severity"]
+        if not isinstance(sev, str):
+            errors.append(
+                Issue(
+                    path=f"{base_path}.severity",
+                    code="bad_severity",
+                    message=f"'severity' must be a string, got {type(sev).__name__}",
+                    severity="error",
+                )
+            )
+            has_error = True
+        elif sev not in ALLOWED_SEVERITIES:
+            errors.append(
+                Issue(
+                    path=f"{base_path}.severity",
+                    code="bad_severity",
+                    message=f"Invalid severity '{sev}'. Allowed: {', '.join(ALLOWED_SEVERITIES)}",
+                    severity="error",
+                )
+            )
+            has_error = True
+
+    if "on_fail" in entry:
+        of = entry["on_fail"]
+        if not isinstance(of, str):
+            errors.append(
+                Issue(
+                    path=f"{base_path}.on_fail",
+                    code="bad_on_fail",
+                    message=f"'on_fail' must be a string, got {type(of).__name__}",
+                    severity="error",
+                )
+            )
+            has_error = True
+        elif of not in ALLOWED_ON_FAIL:
+            errors.append(
+                Issue(
+                    path=f"{base_path}.on_fail",
+                    code="bad_on_fail",
+                    message=f"Invalid on_fail '{of}'. Allowed: {', '.join(ALLOWED_ON_FAIL)}",
+                    severity="error",
+                )
+            )
+            has_error = True
+
+    if "enabled" in entry:
+        en = entry["enabled"]
+        if not isinstance(en, bool):
+            errors.append(
+                Issue(
+                    path=f"{base_path}.enabled",
+                    code="bad_enabled",
+                    message=f"'enabled' must be a bool, got {type(en).__name__}",
+                    severity="error",
+                )
+            )
+            has_error = True
+
+    specific_fields = _get_specific_fields(cls)
+    known_yaml_fields = _COMMON_POLICY_FIELDS | frozenset(specific_fields.keys())
+
+    # Unknown field warnings.
+    for key in entry:
+        if key not in known_yaml_fields:
+            suggestion = _suggest(key, list(known_yaml_fields))
+            msg = f"Unknown field '{key}'"
+            if suggestion:
+                msg += f". Did you mean '{suggestion}'?"
+            warnings.append(
+                Issue(
+                    path=f"{base_path}.{key}",
+                    code="unknown_field",
+                    message=msg,
+                    severity="warning",
+                )
+            )
+
+    # Type-check specific fields.
+    for field_name, expected_type in specific_fields.items():
+        if field_name in entry:
+            value = entry[field_name]
+            try:
+                if not _check_type(value, expected_type):
+                    errors.append(
+                        Issue(
+                            path=f"{base_path}.{field_name}",
+                            code="type_mismatch",
+                            message=(
+                                f"Field '{field_name}' expected {_type_name(expected_type)}, "
+                                f"got {type(value).__name__} ({value!r})"
+                            ),
+                            severity="error",
+                        )
+                    )
+                    has_error = True
+            except Exception:  # noqa: BLE001
+                pass  # Degrade gracefully on exotic type annotations.
+
+    if not has_error:
+        policies_loaded.append(policy_id)
+
+
+def _validate_policies(
+    config: dict[str, Any],
+    errors: list[Issue],
+    warnings: list[Issue],
+    policies_loaded: list[str],
+) -> None:
+    registry = iter_registered_policies()
+
+    # Form 2: top-level "policies" key.
+    if "policies" in config:
+        entries = config["policies"]
+        if not isinstance(entries, list):
+            errors.append(
+                Issue(
+                    path="policies",
+                    code="bad_top_level_type",
+                    message=f"'policies' must be a list, got {type(entries).__name__}",
+                    severity="error",
+                )
+            )
+            return
+        for i, entry in enumerate(entries):
+            _validate_policy_entry(
+                entry, "policies", i, registry, errors, warnings, policies_loaded
+            )
+        return
+
+    # Form 1: per-domain keys.
+    for domain in ("payment", "email"):
+        if domain not in config:
+            continue
+        entries = config[domain]
+        if not isinstance(entries, list):
+            errors.append(
+                Issue(
+                    path=domain,
+                    code="bad_top_level_type",
+                    message=f"'{domain}' must be a list, got {type(entries).__name__}",
+                    severity="error",
+                )
+            )
+            continue
+        if len(entries) == 0:
+            warnings.append(
+                Issue(
+                    path=domain,
+                    code="empty_domain",
+                    message=f"Domain '{domain}' is empty. This is allowed but may be unintentional",
+                    severity="warning",
+                )
+            )
+            continue
+        for i, entry in enumerate(entries):
+            _validate_policy_entry(entry, domain, i, registry, errors, warnings, policies_loaded)
+
+
+def _emit_post_warnings(
+    config: dict[str, Any],
+    policies_loaded: list[str],
+    warnings: list[Issue],
+) -> None:
+    if not policies_loaded:
+        warnings.append(
+            Issue(
+                path="(root)",
+                code="no_policies",
+                message=(
+                    "No policies loaded. Add at least one policy under "
+                    "'payment:', 'email:', or 'policies:'"
+                ),
+                severity="warning",
+            )
+        )
+
+    # Default critical field warnings.
+    entries_with_prefix: list[tuple[str, int, dict[str, Any]]] = []
+    if "policies" in config and isinstance(config["policies"], list):
+        for i, e in enumerate(config["policies"]):
+            if isinstance(e, dict):
+                entries_with_prefix.append(("policies", i, e))
+    else:
+        for domain in ("payment", "email"):
+            if domain in config and isinstance(config[domain], list):
+                for i, e in enumerate(config[domain]):
+                    if isinstance(e, dict):
+                        entries_with_prefix.append((domain, i, e))
+
+    registry = iter_registered_policies()
+    for section, idx, entry in entries_with_prefix:
+        policy_id = entry.get("id")
+        if not isinstance(policy_id, str) or policy_id not in _CRITICAL_FIELDS_BY_POLICY:
+            continue
+        critical_field = _CRITICAL_FIELDS_BY_POLICY[policy_id]
+        if critical_field not in entry:
+            cls = registry.get(policy_id)
+            default_val = _get_field_default(cls, critical_field) if cls else dataclasses.MISSING
+            default_str = f" {default_val}" if default_val is not dataclasses.MISSING else ""
+            warnings.append(
+                Issue(
+                    path=f"{section}[{idx}]",
+                    code="default_critical_field",
+                    message=(
+                        f"Critical field '{critical_field}' not set; "
+                        f"using default{default_str}. "
+                        f"Set it explicitly to silence this warning"
+                    ),
+                    severity="warning",
+                )
+            )
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+
+def validate_config(path: str) -> ValidationReport:
+    """Validate the ``gate.yaml`` file at ``path``.
+
+    Raises:
+        FileNotFoundError: if the file does not exist.
+        OSError: on other I/O errors.
+        ValueError: if the YAML cannot be parsed.
+        ImportError: if PyYAML is not installed (with a helpful message).
+    """
+    try:
+        import yaml  # noqa: PLC0415
+    except ImportError as err:
+        raise ImportError(
+            "PyYAML required to validate YAML files. Install: pip install diplomat-gate[yaml]"
+        ) from err
+
+    with open(path) as f:
+        try:
+            config = yaml.safe_load(f)
+        except yaml.YAMLError as err:
+            raise ValueError(f"YAML parse error: {err}") from err
+
+    if config is None:
+        config = {}
+
+    if not isinstance(config, dict):
+        return ValidationReport(
+            ok=False,
+            errors=(
+                Issue(
+                    path="(root)",
+                    code="bad_top_level_type",
+                    message=f"Top-level must be a mapping, got {type(config).__name__}",
+                    severity="error",
+                ),
+            ),
+            warnings=(),
+            policies_loaded=(),
+            config_path=path,
+        )
+
+    errors: list[Issue] = []
+    warnings: list[Issue] = []
+    policies_loaded: list[str] = []
+
+    _validate_audit_section(config.get("audit"), errors, warnings)
+    _validate_review_queue_section(config.get("review_queue"), errors, warnings)
+    _validate_policies(config, errors, warnings, policies_loaded)
+    _emit_post_warnings(config, policies_loaded, warnings)
+
+    errors_sorted = tuple(sorted(errors, key=lambda i: (i.path, i.code)))
+    warnings_sorted = tuple(sorted(warnings, key=lambda i: (i.path, i.code)))
+    return ValidationReport(
+        ok=len(errors_sorted) == 0,
+        errors=errors_sorted,
+        warnings=warnings_sorted,
+        policies_loaded=tuple(sorted(policies_loaded)),
+        config_path=path,
+    )
+
+
+def report_to_dict(report: ValidationReport) -> dict[str, Any]:
+    """Render a ValidationReport as a JSON-serialisable dict.
+
+    Key order is stable: ok, format_version, config_path, policies_loaded,
+    errors, warnings.
+    """
+
+    def issue_dict(i: Issue) -> dict[str, str]:
+        return {"path": i.path, "code": i.code, "message": i.message, "severity": i.severity}
+
+    return {
+        "ok": report.ok,
+        "format_version": report.format_version,
+        "config_path": report.config_path,
+        "policies_loaded": list(report.policies_loaded),
+        "errors": [issue_dict(i) for i in report.errors],
+        "warnings": [issue_dict(i) for i in report.warnings],
+    }
+
+
+def format_report_text(report: ValidationReport, *, use_color: bool) -> str:
+    """Render a ValidationReport as human-readable text for stdout."""
+    if use_color:
+        green = "\x1b[32m"
+        yellow = "\x1b[33m"
+        red = "\x1b[31m"
+        reset = "\x1b[0m"
+    else:
+        green = yellow = red = reset = ""
+
+    n_pol = len(report.policies_loaded)
+    n_err = len(report.errors)
+    n_warn = len(report.warnings)
+
+    if not report.ok:
+        header = (
+            f"{red}INVALID{reset}: {n_pol} policies loaded, {n_err} error(s), {n_warn} warning(s)"
+        )
+    elif n_warn > 0:
+        header = (
+            f"{yellow}OK with warnings{reset}: {n_pol} policies loaded, "
+            f"0 errors, {n_warn} warning(s)"
+        )
+    else:
+        header = f"{green}OK{reset}: {n_pol} policies loaded, 0 errors, 0 warnings"
+
+    lines = [header]
+    for issue in report.errors:
+        sev_col = f"{red}error{reset}  "
+        lines.append(f"  {sev_col}  {issue.path:<40}  {issue.code:<24}  {issue.message}")
+    for issue in report.warnings:
+        sev_col = f"{yellow}warning{reset}"
+        lines.append(f"  {sev_col}  {issue.path:<40}  {issue.code:<24}  {issue.message}")
+    return "\n".join(lines)

--- a/tests/fixtures/validation/error_audit_bad_type.yaml
+++ b/tests/fixtures/validation/error_audit_bad_type.yaml
@@ -1,0 +1,6 @@
+audit:
+  enabled: "yes"
+  path: 42
+payment:
+  - id: payment.amount_limit
+    max_amount: 1000

--- a/tests/fixtures/validation/error_bad_on_fail.yaml
+++ b/tests/fixtures/validation/error_bad_on_fail.yaml
@@ -1,0 +1,4 @@
+payment:
+  - id: payment.amount_limit
+    max_amount: 1000
+    on_fail: BLOCK

--- a/tests/fixtures/validation/error_bad_severity.yaml
+++ b/tests/fixtures/validation/error_bad_severity.yaml
@@ -1,0 +1,4 @@
+payment:
+  - id: payment.amount_limit
+    max_amount: 1000
+    severity: extreme

--- a/tests/fixtures/validation/error_missing_id.yaml
+++ b/tests/fixtures/validation/error_missing_id.yaml
@@ -1,0 +1,3 @@
+payment:
+  - max_amount: 1000
+    severity: high

--- a/tests/fixtures/validation/error_type_mismatch.yaml
+++ b/tests/fixtures/validation/error_type_mismatch.yaml
@@ -1,0 +1,3 @@
+payment:
+  - id: payment.amount_limit
+    max_amount: "ten thousand"

--- a/tests/fixtures/validation/error_unknown_policy.yaml
+++ b/tests/fixtures/validation/error_unknown_policy.yaml
@@ -1,0 +1,3 @@
+payment:
+  - id: payment.amout_limit
+    max_amount: 1000

--- a/tests/fixtures/validation/malformed_yaml.yaml
+++ b/tests/fixtures/validation/malformed_yaml.yaml
@@ -1,0 +1,3 @@
+payment:
+  - id: payment.amount_limit
+    max_amount: [1, 2, 3

--- a/tests/fixtures/validation/policies_key_form.yaml
+++ b/tests/fixtures/validation/policies_key_form.yaml
@@ -1,0 +1,5 @@
+policies:
+  - id: payment.amount_limit
+    max_amount: 1000
+  - id: email.domain_blocklist
+    blocked: ["*.evil.com"]

--- a/tests/fixtures/validation/valid_full.yaml
+++ b/tests/fixtures/validation/valid_full.yaml
@@ -1,0 +1,55 @@
+# diplomat-gate policy file — https://github.com/Diplomat-ai/diplomat-gate
+version: "1"
+
+audit:
+  enabled: true
+  path: "./diplomat-audit.db"
+
+payment:
+  - id: payment.amount_limit
+    max_amount: 10000
+    severity: critical
+    on_fail: STOP
+
+  - id: payment.velocity
+    max_txn: 20
+    window: 1h
+    severity: high
+    on_fail: STOP
+
+  - id: payment.duplicate_detection
+    window: 5m
+    severity: high
+    on_fail: REVIEW
+
+  - id: payment.recipient_blocklist
+    blocked:
+      - "acct_blacklisted_*"
+    severity: critical
+    on_fail: STOP
+
+email:
+  - id: email.domain_blocklist
+    blocked:
+      - "*.banque-*.fr"
+      - "*.gouv.fr"
+    severity: critical
+    on_fail: STOP
+
+  - id: email.rate_limit
+    max: 50
+    window: 1h
+    severity: high
+    on_fail: STOP
+
+  - id: email.business_hours
+    start: 9
+    end: 18
+    tz: Europe/Paris
+    severity: medium
+    on_fail: REVIEW
+
+  - id: email.content_scan
+    patterns: [credit_card, ssn, api_key, private_key]
+    severity: critical
+    on_fail: STOP

--- a/tests/fixtures/validation/valid_minimal.yaml
+++ b/tests/fixtures/validation/valid_minimal.yaml
@@ -1,0 +1,5 @@
+payment:
+  - id: payment.amount_limit
+    max_amount: 1000
+    severity: high
+    on_fail: STOP

--- a/tests/fixtures/validation/warn_default_critical_field.yaml
+++ b/tests/fixtures/validation/warn_default_critical_field.yaml
@@ -1,0 +1,4 @@
+payment:
+  - id: payment.amount_limit
+    severity: critical
+    on_fail: STOP

--- a/tests/fixtures/validation/warn_empty_domain.yaml
+++ b/tests/fixtures/validation/warn_empty_domain.yaml
@@ -1,0 +1,4 @@
+payment: []
+email:
+  - id: email.domain_blocklist
+    blocked: ["*.evil.com"]

--- a/tests/fixtures/validation/warn_no_policies.yaml
+++ b/tests/fixtures/validation/warn_no_policies.yaml
@@ -1,0 +1,3 @@
+audit:
+  enabled: true
+  path: ./diplomat-audit.db

--- a/tests/fixtures/validation/warn_unknown_field.yaml
+++ b/tests/fixtures/validation/warn_unknown_field.yaml
@@ -1,0 +1,5 @@
+payment:
+  - id: payment.amount_limit
+    max_amout: 1000
+    severity: high
+    on_fail: STOP

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,0 +1,141 @@
+"""Integration tests for `diplomat-gate validate`. Uses subprocess + PYTHONUTF8=1."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURES = REPO / "tests" / "fixtures" / "validation"
+
+ENV = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "diplomat_gate.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=ENV,
+    )
+
+
+@pytest.mark.integration
+def test_cli_validate_help_responds():
+    result = _run("validate", "--help")
+    assert result.returncode == 0
+    assert "validate" in result.stdout.lower()
+
+
+@pytest.mark.integration
+def test_cli_validate_valid_minimal_exit_zero():
+    result = _run("validate", str(FIXTURES / "valid_minimal.yaml"))
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_validate_invalid_exit_one():
+    result = _run("validate", str(FIXTURES / "error_unknown_policy.yaml"))
+    assert result.returncode == 1
+    assert "INVALID" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_validate_missing_file_exit_two(tmp_path):
+    nope = tmp_path / "nope.yaml"
+    result = _run("validate", str(nope))
+    assert result.returncode == 2
+    assert "file not found" in result.stderr.lower()
+
+
+@pytest.mark.integration
+def test_cli_validate_json_flag_outputs_valid_json():
+    result = _run("validate", str(FIXTURES / "valid_minimal.yaml"), "--json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["format_version"] == "1"
+    assert list(payload.keys()) == [
+        "ok",
+        "format_version",
+        "config_path",
+        "policies_loaded",
+        "errors",
+        "warnings",
+    ]
+
+
+@pytest.mark.integration
+def test_cli_validate_quiet_suppresses_stdout():
+    result = _run("validate", str(FIXTURES / "valid_minimal.yaml"), "--quiet")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+@pytest.mark.integration
+def test_cli_validate_quiet_invalid_still_exits_one():
+    result = _run("validate", str(FIXTURES / "error_unknown_policy.yaml"), "--quiet")
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+@pytest.mark.integration
+def test_cli_validate_output_writes_file(tmp_path):
+    out = tmp_path / "report.json"
+    result = _run(
+        "validate",
+        str(FIXTURES / "valid_minimal.yaml"),
+        "--output",
+        str(out),
+        "--quiet",
+    )
+    assert result.returncode == 0
+    assert out.exists()
+    payload = json.loads(out.read_text())
+    assert payload["ok"] is True
+    assert payload["format_version"] == "1"
+
+
+@pytest.mark.integration
+def test_cli_validate_no_color_global_flag():
+    """--no-color is a parser-level flag — must come BEFORE the subcommand."""
+    result = _run("--no-color", "validate", str(FIXTURES / "valid_minimal.yaml"))
+    assert result.returncode == 0
+    assert "\x1b[" not in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_validate_full_example_passes():
+    """The shipped gate.yaml.example must validate cleanly (exit 0)."""
+    result = _run("validate", str(REPO / "gate.yaml.example"))
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_validate_warn_shows_ok_with_warnings():
+    result = _run("validate", str(FIXTURES / "warn_unknown_field.yaml"))
+    assert result.returncode == 0
+    assert "OK with warnings" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_validate_output_and_stdout_both_produced(tmp_path):
+    """Without --quiet, --output still shows summary on stdout."""
+    out = tmp_path / "report.json"
+    result = _run(
+        "validate",
+        str(FIXTURES / "valid_minimal.yaml"),
+        "--output",
+        str(out),
+    )
+    assert result.returncode == 0
+    assert out.exists()
+    assert result.stdout.strip()  # summary on stdout

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from diplomat_gate.policies import load_from_dict
+from diplomat_gate.policies import iter_registered_policies, load_from_dict
 from diplomat_gate.policies.emails import DomainBlocklistPolicy
 from diplomat_gate.policies.payments import AmountLimitPolicy, VelocityPolicy
 
@@ -59,3 +59,21 @@ class TestLoadFromDict:
         assert isinstance(policies[0], VelocityPolicy)
         assert policies[0].window == "30m"
         assert policies[0].max_txn == 5
+
+
+class TestIterRegisteredPolicies:
+    def test_returns_all_nine_policies(self):
+        registry = iter_registered_policies()
+        assert len(registry) == 9
+
+    def test_iter_registered_policies_is_a_copy(self):
+        registry = iter_registered_policies()
+        original_len = len(registry)
+        registry["fake.policy"] = object  # type: ignore[assignment]
+        # Mutation of the returned dict must not affect the internal registry
+        assert len(iter_registered_policies()) == original_len
+
+    def test_contains_expected_ids(self):
+        registry = iter_registered_policies()
+        assert "payment.amount_limit" in registry
+        assert "email.domain_blocklist" in registry

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,613 @@
+"""Unit tests for diplomat_gate.validation (no subprocess)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from diplomat_gate.validation import (
+    Issue,
+    ValidationReport,
+    format_report_text,
+    report_to_dict,
+    validate_config,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "validation"
+
+
+# ── Happy paths ────────────────────────────────────────────────────────────────
+
+
+def test_valid_minimal_returns_ok():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    assert report.ok is True
+    assert report.errors == ()
+    assert "payment.amount_limit" in report.policies_loaded
+
+
+def test_valid_minimal_no_warnings():
+    # valid_minimal has max_amount set explicitly — no default_critical_field warning.
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    assert report.warnings == ()
+
+
+def test_valid_full_matches_example():
+    report = validate_config(str(FIXTURES / "valid_full.yaml"))
+    assert report.ok is True
+    assert report.errors == ()
+    assert len(report.policies_loaded) >= 8
+
+
+def test_policies_key_form_supported():
+    report = validate_config(str(FIXTURES / "policies_key_form.yaml"))
+    assert report.ok is True
+    assert "payment.amount_limit" in report.policies_loaded
+    assert "email.domain_blocklist" in report.policies_loaded
+
+
+def test_format_version_is_stable():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    assert report.format_version == "1"
+
+
+# ── Errors ─────────────────────────────────────────────────────────────────────
+
+
+def test_unknown_policy_id_errors():
+    report = validate_config(str(FIXTURES / "error_unknown_policy.yaml"))
+    assert report.ok is False
+    assert any(e.code == "unknown_policy" for e in report.errors)
+    issue = next(e for e in report.errors if e.code == "unknown_policy")
+    assert issue.path.endswith(".id")
+    # difflib should suggest 'payment.amount_limit' for the typo 'payment.amout_limit'
+    assert "amount_limit" in issue.message.lower() or "did you mean" in issue.message.lower()
+
+
+def test_missing_id_errors():
+    report = validate_config(str(FIXTURES / "error_missing_id.yaml"))
+    assert report.ok is False
+    assert any(e.code == "missing_id" for e in report.errors)
+
+
+def test_bad_severity_errors():
+    report = validate_config(str(FIXTURES / "error_bad_severity.yaml"))
+    assert report.ok is False
+    assert any(e.code == "bad_severity" for e in report.errors)
+
+
+def test_bad_on_fail_errors():
+    report = validate_config(str(FIXTURES / "error_bad_on_fail.yaml"))
+    assert report.ok is False
+    assert any(e.code == "bad_on_fail" for e in report.errors)
+
+
+def test_type_mismatch_errors():
+    report = validate_config(str(FIXTURES / "error_type_mismatch.yaml"))
+    assert report.ok is False
+    assert any(e.code == "type_mismatch" for e in report.errors)
+    issue = next(e for e in report.errors if e.code == "type_mismatch")
+    assert "max_amount" in issue.path
+
+
+def test_audit_bad_type_errors():
+    report = validate_config(str(FIXTURES / "error_audit_bad_type.yaml"))
+    assert report.ok is False
+    assert any(e.code == "audit_bad_type" for e in report.errors)
+    # Both enabled (str) and path (int) should be reported.
+    audit_errors = [e for e in report.errors if e.code == "audit_bad_type"]
+    assert len(audit_errors) == 2
+
+
+# ── Warnings ───────────────────────────────────────────────────────────────────
+
+
+def test_unknown_field_warns():
+    report = validate_config(str(FIXTURES / "warn_unknown_field.yaml"))
+    assert report.ok is True
+    assert any(w.code == "unknown_field" for w in report.warnings)
+    w = next(w for w in report.warnings if w.code == "unknown_field")
+    # difflib should suggest 'max_amount' for the typo 'max_amout'
+    assert "max_amount" in w.message
+
+
+def test_default_critical_field_warns():
+    report = validate_config(str(FIXTURES / "warn_default_critical_field.yaml"))
+    assert report.ok is True
+    assert any(w.code == "default_critical_field" for w in report.warnings)
+    w = next(w for w in report.warnings if w.code == "default_critical_field")
+    assert "max_amount" in w.message
+    assert "10000" in w.message
+
+
+def test_empty_domain_warns():
+    report = validate_config(str(FIXTURES / "warn_empty_domain.yaml"))
+    assert any(w.code == "empty_domain" for w in report.warnings)
+    w = next(w for w in report.warnings if w.code == "empty_domain")
+    assert w.path == "payment"
+
+
+def test_no_policies_warns():
+    report = validate_config(str(FIXTURES / "warn_no_policies.yaml"))
+    assert any(w.code == "no_policies" for w in report.warnings)
+
+
+# ── Robustness ─────────────────────────────────────────────────────────────────
+
+
+def test_yaml_parse_error_raises_value_error(tmp_path):
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("payment:\n  - id: payment.amount_limit\n    max_amount: [1, 2, 3\n")
+    with pytest.raises(ValueError, match="YAML parse error"):
+        validate_config(str(bad))
+
+
+def test_missing_file_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        validate_config("/nonexistent/path/gate.yaml")
+
+
+def test_top_level_not_mapping_returns_error(tmp_path):
+    bad = tmp_path / "list_at_root.yaml"
+    bad.write_text("- foo\n- bar\n")
+    report = validate_config(str(bad))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" for e in report.errors)
+
+
+def test_empty_file_no_policies_warning(tmp_path):
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("")
+    report = validate_config(str(empty))
+    assert report.ok is True
+    assert any(w.code == "no_policies" for w in report.warnings)
+
+
+# ── Diffability ────────────────────────────────────────────────────────────────
+
+
+def test_errors_are_sorted_stably():
+    report = validate_config(str(FIXTURES / "error_audit_bad_type.yaml"))
+    pairs = [(e.path, e.code) for e in report.errors]
+    assert pairs == sorted(pairs)
+
+
+def test_report_to_dict_key_order_is_stable():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    d = report_to_dict(report)
+    assert list(d.keys()) == [
+        "ok",
+        "format_version",
+        "config_path",
+        "policies_loaded",
+        "errors",
+        "warnings",
+    ]
+
+
+def test_report_to_dict_policies_loaded_is_sorted():
+    report = validate_config(str(FIXTURES / "valid_full.yaml"))
+    d = report_to_dict(report)
+    assert d["policies_loaded"] == sorted(d["policies_loaded"])
+
+
+def test_report_is_json_serialisable():
+    import json
+
+    report = validate_config(str(FIXTURES / "valid_full.yaml"))
+    d = report_to_dict(report)
+    payload = json.dumps(d)  # must not raise
+    reparsed = json.loads(payload)
+    assert reparsed["ok"] is True
+    assert reparsed["format_version"] == "1"
+
+
+# ── Format text ────────────────────────────────────────────────────────────────
+
+
+def test_format_report_text_no_color():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    text = format_report_text(report, use_color=False)
+    assert "OK" in text
+    assert "\x1b[" not in text  # no ANSI escape codes
+
+
+def test_format_report_text_with_color():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    text = format_report_text(report, use_color=True)
+    assert "\x1b[" in text
+
+
+def test_format_report_text_invalid_contains_error_lines():
+    report = validate_config(str(FIXTURES / "error_unknown_policy.yaml"))
+    text = format_report_text(report, use_color=False)
+    assert "INVALID" in text
+    assert "unknown_policy" in text
+
+
+def test_format_report_text_warnings():
+    report = validate_config(str(FIXTURES / "warn_unknown_field.yaml"))
+    text = format_report_text(report, use_color=False)
+    assert "OK with warnings" in text
+    assert "unknown_field" in text
+
+
+# ── Type checking edge cases ───────────────────────────────────────────────────
+
+
+def test_bool_is_not_accepted_for_int_field(tmp_path):
+    bad = tmp_path / "bool_for_int.yaml"
+    bad.write_text("email:\n  - id: email.business_hours\n    start: true\n    end: 18\n")
+    report = validate_config(str(bad))
+    assert report.ok is False
+    assert any(e.code == "type_mismatch" and "start" in e.path for e in report.errors)
+
+
+def test_int_is_accepted_for_float_field(tmp_path):
+    ok = tmp_path / "int_for_float.yaml"
+    ok.write_text("payment:\n  - id: payment.amount_limit\n    max_amount: 10000\n")
+    report = validate_config(str(ok))
+    assert report.ok is True
+
+
+def test_list_of_strings_passes_type_check(tmp_path):
+    f = tmp_path / "list_str.yaml"
+    f.write_text(
+        'email:\n  - id: email.domain_blocklist\n    blocked: ["*.evil.com", "*.bad.net"]\n'
+    )
+    report = validate_config(str(f))
+    assert report.ok is True
+
+
+def test_list_of_wrong_type_fails(tmp_path):
+    f = tmp_path / "list_wrong.yaml"
+    f.write_text(
+        "email:\n"
+        "  - id: email.business_hours\n"
+        "    days: [monday, tuesday]\n"  # list[str] but expects list[int]
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "type_mismatch" for e in report.errors)
+
+
+# ── Policies loaded tracking ───────────────────────────────────────────────────
+
+
+def test_failed_policy_not_in_policies_loaded():
+    report = validate_config(str(FIXTURES / "error_bad_severity.yaml"))
+    assert "payment.amount_limit" not in report.policies_loaded
+
+
+def test_unknown_policy_not_in_policies_loaded():
+    report = validate_config(str(FIXTURES / "error_unknown_policy.yaml"))
+    assert report.policies_loaded == ()
+
+
+# ── Review queue section ───────────────────────────────────────────────────────
+
+
+def test_review_queue_bad_enabled_errors(tmp_path):
+    f = tmp_path / "rq.yaml"
+    f.write_text(
+        "review_queue:\n"
+        "  enabled: maybe\n"
+        "  path: ./review.db\n"
+        "payment:\n"
+        "  - id: payment.amount_limit\n"
+        "    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "review_queue_bad_type" and "enabled" in e.path for e in report.errors)
+
+
+def test_review_queue_bad_path_errors(tmp_path):
+    f = tmp_path / "rq_path.yaml"
+    f.write_text(
+        "review_queue:\n"
+        "  enabled: true\n"
+        "  path: 99\n"
+        "payment:\n"
+        "  - id: payment.amount_limit\n"
+        "    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "review_queue_bad_type" and "path" in e.path for e in report.errors)
+
+
+def test_review_queue_unknown_field_warns(tmp_path):
+    f = tmp_path / "rq_warn.yaml"
+    f.write_text(
+        "review_queue:\n"
+        "  enabled: true\n"
+        "  ttl_secs: 3600\n"  # typo for ttl_seconds
+        "payment:\n"
+        "  - id: payment.amount_limit\n"
+        "    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is True
+    assert any(w.code == "unknown_review_queue_field" for w in report.warnings)
+
+
+def test_review_queue_not_mapping_errors(tmp_path):
+    f = tmp_path / "rq_bad.yaml"
+    f.write_text(
+        "review_queue: notamapping\npayment:\n  - id: payment.amount_limit\n    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" and e.path == "review_queue" for e in report.errors)
+
+
+# ── Audit section extra branches ───────────────────────────────────────────────
+
+
+def test_audit_not_mapping_errors(tmp_path):
+    f = tmp_path / "audit_bad.yaml"
+    f.write_text(
+        "audit: notamapping\npayment:\n  - id: payment.amount_limit\n    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" and e.path == "audit" for e in report.errors)
+
+
+def test_audit_unknown_field_with_suggestion(tmp_path):
+    f = tmp_path / "audit_typo.yaml"
+    f.write_text(
+        "audit:\n"
+        "  enabeld: true\n"  # typo for enabled
+        "  path: ./audit.db\n"
+        "payment:\n"
+        "  - id: payment.amount_limit\n"
+        "    max_amount: 1000\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is True
+    assert any(w.code == "unknown_audit_field" for w in report.warnings)
+
+
+# ── Policies section extra branches ────────────────────────────────────────────
+
+
+def test_policies_key_not_list_errors(tmp_path):
+    f = tmp_path / "policies_bad.yaml"
+    f.write_text("policies: notalist\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" and e.path == "policies" for e in report.errors)
+
+
+def test_domain_not_list_errors(tmp_path):
+    f = tmp_path / "domain_bad.yaml"
+    f.write_text("payment: notalist\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" and e.path == "payment" for e in report.errors)
+
+
+def test_policy_entry_not_dict_errors(tmp_path):
+    f = tmp_path / "entry_bad.yaml"
+    f.write_text("payment:\n  - just_a_string\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" for e in report.errors)
+
+
+def test_on_fail_not_string_errors(tmp_path):
+    f = tmp_path / "on_fail_bad.yaml"
+    f.write_text("payment:\n  - id: payment.amount_limit\n    max_amount: 1000\n    on_fail: 42\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_on_fail" for e in report.errors)
+
+
+def test_enabled_not_bool_errors(tmp_path):
+    f = tmp_path / "enabled_bad.yaml"
+    f.write_text(
+        "payment:\n"
+        "  - id: payment.amount_limit\n"
+        "    max_amount: 1000\n"
+        "    enabled: yes\n"  # PyYAML parses "yes" as bool True, use string
+    )
+    # PyYAML parses unquoted 'yes' as True (bool), so use a string explicitly
+    f.write_text(
+        "payment:\n  - id: payment.amount_limit\n    max_amount: 1000\n    enabled: 'maybe'\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_enabled" for e in report.errors)
+
+
+def test_default_critical_field_policies_key_form(tmp_path):
+    """default_critical_field warning fires for the 'policies:' key form too."""
+    f = tmp_path / "crit.yaml"
+    f.write_text(
+        "policies:\n  - id: payment.amount_limit\n    severity: critical\n    on_fail: STOP\n"
+    )
+    report = validate_config(str(f))
+    assert report.ok is True
+    assert any(w.code == "default_critical_field" for w in report.warnings)
+    w = next(w for w in report.warnings if w.code == "default_critical_field")
+    assert w.path == "policies[0]"
+
+
+def test_id_not_string_errors(tmp_path):
+    f = tmp_path / "id_num.yaml"
+    f.write_text("payment:\n  - id: 42\n    max_amount: 1000\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "missing_id" for e in report.errors)
+
+
+def test_dict_type_field_accepted(tmp_path):
+    """A field typed as dict[str, Any] accepts a dict value."""
+    # Use Policy.config field — but config is excluded from specific fields.
+    # Instead, test via an int field passed as dict to trigger type_mismatch.
+    f = tmp_path / "dict_type.yaml"
+    f.write_text(
+        "payment:\n  - id: payment.velocity\n    max_txn: {nested: value}\n"  # dict instead of int
+    )
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "type_mismatch" and "max_txn" in e.path for e in report.errors)
+
+
+# ── format_report_text colour/no-colour ────────────────────────────────────────
+
+
+def test_format_report_text_color_invalid():
+    report = ValidationReport(
+        ok=False,
+        errors=(Issue(path="payment[0].id", code="missing_id", message="No id", severity="error"),),
+        warnings=(),
+        policies_loaded=(),
+        config_path="test.yaml",
+    )
+    text = format_report_text(report, use_color=True)
+    assert "\x1b[31m" in text
+    assert "INVALID" in text
+    assert "missing_id" in text
+
+
+def test_format_report_text_color_ok_with_warnings():
+    report = ValidationReport(
+        ok=True,
+        errors=(),
+        warnings=(
+            Issue(
+                path="payment[0].max_amout",
+                code="unknown_field",
+                message="typo",
+                severity="warning",
+            ),
+        ),
+        policies_loaded=("payment.amount_limit",),
+        config_path="test.yaml",
+    )
+    text = format_report_text(report, use_color=True)
+    assert "\x1b[33m" in text
+    assert "OK with warnings" in text
+
+
+def test_format_report_text_no_color_ok():
+    report = ValidationReport(
+        ok=True,
+        errors=(),
+        warnings=(),
+        policies_loaded=("payment.amount_limit",),
+        config_path="test.yaml",
+    )
+    text = format_report_text(report, use_color=False)
+    assert "\x1b[" not in text
+    assert "OK:" in text
+
+
+# ── report_to_dict ─────────────────────────────────────────────────────────────
+
+
+def test_report_to_dict_includes_all_keys():
+    report = validate_config(str(FIXTURES / "valid_minimal.yaml"))
+    d = report_to_dict(report)
+    assert list(d.keys()) == [
+        "ok",
+        "format_version",
+        "config_path",
+        "policies_loaded",
+        "errors",
+        "warnings",
+    ]
+
+
+# ── top-level non-mapping ──────────────────────────────────────────────────────
+
+
+def test_top_level_non_mapping_errors(tmp_path):
+    f = tmp_path / "bad_root.yaml"
+    f.write_text("- item1\n- item2\n")
+    report = validate_config(str(f))
+    assert report.ok is False
+    assert any(e.code == "bad_top_level_type" and e.path == "(root)" for e in report.errors)
+
+
+def test_empty_yaml_gives_no_policies_warning(tmp_path):
+    f = tmp_path / "empty.yaml"
+    f.write_text("")
+    report = validate_config(str(f))
+    assert report.ok is True
+    assert any(w.code == "no_policies" for w in report.warnings)
+
+
+# ── _type_name for dict fields ─────────────────────────────────────────────────
+
+
+def test_type_name_for_list_dict_fields():
+    """Ensure type annotations on list[str] fields produce readable names in error messages."""
+    from typing import get_type_hints
+
+    from diplomat_gate.policies.emails import DomainBlocklistPolicy
+    from diplomat_gate.validation import _type_name  # noqa: PLC0415
+
+    hints = get_type_hints(DomainBlocklistPolicy)
+    assert "blocked" in hints
+    name = _type_name(hints["blocked"])
+    assert "list" in name
+
+
+# ── _type_name and _check_type internals ──────────────────────────────────────
+
+
+def test_type_name_dict_generic():
+    from diplomat_gate.validation import _type_name  # noqa: PLC0415
+
+    assert _type_name(dict[str, int]) == "dict[str, int]"
+
+
+def test_type_name_unknown_generic():
+    from diplomat_gate.validation import _type_name  # noqa: PLC0415
+
+    # Optional[int] has a union origin that is neither list nor dict
+    result = _type_name(int | None)  # noqa: UP007
+    assert isinstance(result, str)
+
+
+def test_check_type_typing_any():
+    from typing import Any
+
+    from diplomat_gate.validation import _check_type  # noqa: PLC0415
+
+    assert _check_type("anything", Any) is True
+    assert _check_type(42, Any) is True
+
+
+def test_check_type_list_with_wrong_item():
+    from diplomat_gate.validation import _check_type  # noqa: PLC0415
+
+    assert _check_type(["a", "b"], list[str]) is True
+    assert _check_type(["a", 1], list[str]) is False
+
+
+def test_check_type_dict_generic():
+    from diplomat_gate.validation import _check_type  # noqa: PLC0415
+
+    assert _check_type({"a": 1}, dict[str, int]) is True
+    assert _check_type({"a": "x"}, dict[str, int]) is False
+
+
+def test_check_type_list_no_args():
+    """list without type args always accepts."""
+    from diplomat_gate.validation import _check_type  # noqa: PLC0415
+
+    assert _check_type([1, "mixed"], list) is True  # type: ignore[type-arg]
+
+
+def test_check_type_bool_rejected_for_int_and_float():
+    from diplomat_gate.validation import _check_type  # noqa: PLC0415
+
+    assert _check_type(True, int) is False
+    assert _check_type(True, float) is False
+    assert _check_type(True, bool) is True


### PR DESCRIPTION
## Summary

Implements `diplomat-gate validate <gate.yaml>` — a static analysis CLI command that detects errors and warnings in a `gate.yaml` file before runtime.

Closes #7

## Changes

| File | Change |
|------|--------|
| `src/diplomat_gate/validation.py` | New ~680-line pure validation module (`validate_config`, `ValidationReport`, `Issue`) |
| `src/diplomat_gate/cli.py` | `validate` subparser with `--json`, `--output`, `--quiet` |
| `src/diplomat_gate/policies/loader.py` | New `iter_registered_policies()` accessor |
| `src/diplomat_gate/policies/__init__.py` | Exports `iter_registered_policies` |
| `tests/test_validation.py` | 61 unit tests |
| `tests/test_cli_validate.py` | 12 integration tests (subprocess) |
| `tests/test_loader.py` | 3 new tests for `iter_registered_policies` |
| `tests/fixtures/validation/` | 14 YAML fixture files |
| `examples/09_validate_in_ci.py` | CI usage example |
| `docs/cli.md` | Full CLI reference |
| `README.md` | "Validate your gate.yaml" section |
| `scripts/validate_release.py` | Steps 10bis/10ter added, renumbered to /13 |
| `CHANGELOG.md` | `[Unreleased]` section updated |

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Valid — 0 errors |
| 1 | Invalid — ≥ 1 errors |
| 2 | File not found or YAML parse error |

## Testing

```
235 passed in 12.19s
Coverage: 87% (≥ 80% required)
ruff: All checks passed (52 files)
JSON output: byte-stable across 2 runs
```

Smoke tests:
```
$ diplomat-gate validate gate.yaml.example
OK: 8 policies loaded, 0 errors, 0 warnings   → exit 0

$ diplomat-gate validate tests/fixtures/validation/error_unknown_policy.yaml
INVALID: 0 policies loaded, 1 errors, 1 warnings
  error  payment[0].id  unknown_policy  Unknown policy id ...   → exit 1

$ diplomat-gate validate /nonexistent.yaml
error: file not found: /nonexistent.yaml   → exit 2
```

## Scope

26 files changed, 1916 insertions(+), 22 deletions(–).
No changes to `_version.py`, `pyproject.toml`, `engine.py`, `models.py`, `audit.py`, `review.py`, `state.py`, `decorator.py`, or `exceptions.py`.

## Notes

- Commits are not GPG-signed (GPG not installed on the development machine). The `Verified` badge will be absent; this can be addressed in a follow-up if required by repo policy.