### PR TITLE
chore(release): harden gate with README surface check (14 steps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Also works with Anthropic tool_use, CrewAI, AutoGen, PythonClaw, and any agent f
 
 - **Reproducible OpenClaw demo** — `python demos/openclaw/run.py` shows
   the insurance email incident in under 60 seconds, no API key needed.
-- **Release validation pipeline** — `scripts/validate_release.py` runs an
-  11-step gate: lint → tests → benchmarks → build → install → smoke → demo.
+- **Release validation pipeline** — `scripts/validate_release.py` runs a
+  14-step gate: lint → tests → benchmarks → build → install → smoke → demo.
 
 ## What's new in 0.2.0
 
@@ -441,8 +441,8 @@ trail, real-time dashboard, managed approval routing, compliance export
 diplomat-gate is solo-maintained and AI-assisted: a large share of the commits
 are authored by me but committed through an AI coding agent. What matters for a
 security tool is not who typed the lines but whether the behavior is verifiable.
-The credibility anchors are the ones you can check yourself: 146 tests, an
-11-step release gate (`scripts/validate_release.py`), a green CI matrix across
+The credibility anchors are the ones you can check yourself: 146 tests, a
+14-step release gate (`scripts/validate_release.py`), a green CI matrix across
 Python 3.10–3.13 on Linux / Windows / macOS, and runnable examples that need no
 API key. Run `python -m pytest tests/ -v` and `python benchmarks/run.py` and
 judge the tool on its output.

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Release validation gate — 13 steps, stop at first failure.
+"""Release validation gate — 14 steps, stop at first failure.
 
 Usage:
     python scripts/validate_release.py
@@ -10,6 +10,7 @@ Exit 0 if all pass, exit 1 on first failure.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 PYTHON = sys.executable
+TOTAL_STEPS = 14
 
 
 def _run(
@@ -46,14 +48,109 @@ def _check(step: str, cmd: list[str], *, cwd: Path | None = None) -> bool:
     return False
 
 
+def _surface_check() -> bool:
+    """Step 14 — README surface consistency (4 sub-checks aggregated)."""
+    label = f"[{TOTAL_STEPS}/{TOTAL_STEPS} README surface check]"
+    readme_path = REPO / "README.md"
+    pyproject_path = REPO / "pyproject.toml"
+
+    if not readme_path.exists() or not pyproject_path.exists():
+        print(f"  ✗ FAIL  {label}")
+        print("         README.md or pyproject.toml not found")
+        return False
+
+    readme = readme_path.read_text(encoding="utf-8")
+    pyproject_text = pyproject_path.read_text(encoding="utf-8")
+    failures: list[str] = []
+    notes: list[str] = []
+
+    # Check A — every actions/workflows/X.yml referenced in README must exist.
+    workflows_dir = REPO / ".github" / "workflows"
+    for wf in sorted(set(re.findall(r"actions/workflows/([\w.-]+\.yml)", readme))):
+        if not (workflows_dir / wf).exists():
+            failures.append(
+                f"A: README references actions/workflows/{wf} but .github/workflows/{wf} missing"
+            )
+
+    # Check B — every diplomat-gate[<extra>] in README must exist in pyproject.
+    extras_in_readme = sorted(set(re.findall(r"diplomat-gate\[(\w+)\]", readme)))
+    declared_extras: set[str] = set()
+    try:
+        import tomllib  # type: ignore[import-not-found]
+
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+        declared_extras = set(
+            data.get("project", {}).get("optional-dependencies", {}).keys()
+        )
+    except ImportError:
+        # Python 3.10 fallback: best-effort regex parse of the section.
+        section = re.search(
+            r"\[project\.optional-dependencies\](.*?)(?:\n\[|\Z)",
+            pyproject_text,
+            re.DOTALL,
+        )
+        if section:
+            declared_extras = set(re.findall(r"^(\w+)\s*=", section.group(1), re.MULTILINE))
+    for extra in extras_in_readme:
+        if extra not in declared_extras:
+            failures.append(
+                f"B: README uses diplomat-gate[{extra}] but extra not declared in pyproject.toml"
+            )
+
+    # Check C — yaml blocks with `version:` in first two non-comment lines must parse.
+    try:
+        import yaml as _yaml  # type: ignore[import-not-found]
+    except ImportError:
+        _yaml = None
+        notes.append("Check C skipped (pyyaml not installed)")
+
+    if _yaml is not None:
+        for m in re.finditer(r"```yaml\n(.*?)```", readme, re.DOTALL):
+            block = m.group(1)
+            head = [
+                ln
+                for ln in block.splitlines()
+                if ln.strip() and not ln.lstrip().startswith("#")
+            ][:2]
+            if any("version:" in ln for ln in head):
+                try:
+                    _yaml.safe_load(block)
+                except Exception as exc:
+                    failures.append(f"C: yaml block with 'version:' fails to parse: {exc}")
+
+    # Check D — every '<N>-step' mention in README must equal TOTAL_STEPS.
+    step_counts = set(int(m) for m in re.findall(r"(\d+)-step", readme))
+    if not step_counts:
+        failures.append(
+            f"D: README mentions no '<N>-step' value; script declares {TOTAL_STEPS}"
+        )
+    elif step_counts != {TOTAL_STEPS}:
+        failures.append(
+            f"D: README mentions {sorted(step_counts)} '-step' value(s); script declares {TOTAL_STEPS}"
+        )
+
+    if failures:
+        print(f"  ✗ FAIL  {label}")
+        for line in failures[:6]:
+            print(f"         {line}")
+        for note in notes:
+            print(f"         ({note})")
+        return False
+    print(f"  ✓ PASS  {label}")
+    for note in notes:
+        print(f"         ({note})")
+    return True
+
+
 def main() -> None:
     print(f"\n  diplomat-gate release validation\n  {'─' * 40}")
 
     steps: list[tuple[str, list[str]]] = [
-        ("1/13 ruff check", [PYTHON, "-m", "ruff", "check", "."]),
-        ("2/13 ruff format", [PYTHON, "-m", "ruff", "format", "--check", "."]),
+        ("1/14 ruff check", [PYTHON, "-m", "ruff", "check", "."]),
+        ("2/14 ruff format", [PYTHON, "-m", "ruff", "format", "--check", "."]),
         (
-            "3/13 pytest --cov",
+            "3/14 pytest --cov",
             [
                 PYTHON,
                 "-m",
@@ -65,11 +162,11 @@ def main() -> None:
             ],
         ),
         (
-            "4/13 pytest integration",
+            "4/14 pytest integration",
             [PYTHON, "-m", "pytest", "-m", "integration", "-q", "--tb=short"],
         ),
         (
-            "5/13 benchmarks p95<5ms",
+            "5/14 benchmarks p95<5ms",
             [
                 PYTHON,
                 "benchmarks/run.py",
@@ -79,8 +176,8 @@ def main() -> None:
                 "5.0",
             ],
         ),
-        ("6/13 build sdist+wheel", [PYTHON, "-m", "build"]),
-        ("7/13 twine check", [PYTHON, "-m", "twine", "check", "dist/*"]),
+        ("6/14 build sdist+wheel", [PYTHON, "-m", "build"]),
+        ("7/14 twine check", [PYTHON, "-m", "twine", "check", "dist/*"]),
     ]
 
     for step, cmd in steps:
@@ -89,10 +186,10 @@ def main() -> None:
 
     # Step 8 — fresh venv smoke install
     print(f"  {'─' * 40}")
-    print("  [8/13 fresh-venv smoke install]", flush=True)
+    print("  [8/14 fresh-venv smoke install]", flush=True)
     dist_wheels = sorted(REPO.glob("dist/*.whl"))
     if not dist_wheels:
-        print("  ✗ FAIL  [8/13] no wheel found in dist/")
+        print("  ✗ FAIL  [8/14] no wheel found in dist/")
         sys.exit(1)
     wheel = dist_wheels[-1]
     with tempfile.TemporaryDirectory() as tmp:
@@ -100,50 +197,54 @@ def main() -> None:
         venv = tmp_path / "venv"
         r1 = _run([PYTHON, "-m", "venv", str(venv)])
         if r1.returncode != 0:
-            print("  ✗ FAIL  [8/13] venv creation failed")
+            print("  ✗ FAIL  [8/14] venv creation failed")
             sys.exit(1)
         venv_python = venv / ("Scripts" if sys.platform == "win32" else "bin") / "python"
         r2 = _run([str(venv_python), "-m", "pip", "install", str(wheel), "--quiet"])
         if r2.returncode != 0:
-            print("  ✗ FAIL  [8/13] pip install failed")
+            print("  ✗ FAIL  [8/14] pip install failed")
             lines = (r2.stderr or r2.stdout or "").splitlines()[:3]
             for ln in lines:
                 print(f"         {ln}")
             sys.exit(1)
-        print("  ✓ PASS  [8/13 fresh-venv smoke install]")
+        print("  ✓ PASS  [8/14 fresh-venv smoke install]")
 
         # Step 9 — diplomat-gate --help
         venv_bin = venv / ("Scripts" if sys.platform == "win32" else "bin")
         diplomat_cmd = venv_bin / (
             "diplomat-gate.exe" if sys.platform == "win32" else "diplomat-gate"
         )
-        if not _check("9/13 diplomat-gate --help", [str(diplomat_cmd), "--help"]):
+        if not _check("9/14 diplomat-gate --help", [str(diplomat_cmd), "--help"]):
             sys.exit(1)
 
         # Step 10 — audit verify --help
         if not _check(
-            "10/13 audit verify --help", [str(diplomat_cmd), "audit", "verify", "--help"]
+            "10/14 audit verify --help", [str(diplomat_cmd), "audit", "verify", "--help"]
         ):
             sys.exit(1)
 
-        # Step 10bis — validate --help
-        if not _check("10bis/13 validate --help", [str(diplomat_cmd), "validate", "--help"]):
+        # Step 11 — validate --help
+        if not _check("11/14 validate --help", [str(diplomat_cmd), "validate", "--help"]):
             sys.exit(1)
 
-        # Step 10ter — validate gate.yaml.example
+        # Step 12 — validate gate.yaml.example
         if not _check(
-            "10ter/13 validate gate.yaml.example",
+            "12/14 validate gate.yaml.example",
             [str(diplomat_cmd), "validate", str(REPO / "gate.yaml.example")],
         ):
             sys.exit(1)
 
-    # Step 11 — demo --ci
+    # Step 13 — demo --ci
     demo_path = REPO / "demos" / "openclaw" / "run.py"
     if demo_path.exists():
-        if not _check("11/13 demo --ci", [PYTHON, str(demo_path), "--ci"]):
+        if not _check("13/14 demo --ci", [PYTHON, str(demo_path), "--ci"]):
             sys.exit(1)
     else:
-        print("  ⚠ SKIP  [11/13 demo --ci] demos/openclaw/run.py not yet created (Phase 2)")
+        print("  ⚠ SKIP  [13/14 demo --ci] demos/openclaw/run.py not yet created")
+
+    # Step 14 — README surface consistency check
+    if not _surface_check():
+        sys.exit(1)
 
     print(f"\n  {'─' * 40}")
     print("  All checks passed. Ready to release.\n")


### PR DESCRIPTION
## T-R2 — Harden release gate against README↔code drift

### Why
The previous 11-step gate validated build/test/install artifacts but
ignored the **copyable surface** of the README: badge links, pip extras,
yaml snippets, and step-count claims. Drift between docs and reality is a
credibility bug for a security tool — and the README itself was already
out of sync (claimed "11-step" while the script ran 13 steps with leftover
`10bis`/`10ter` labels).

### What changed
- `scripts/validate_release.py`: clean renumber **1..14** (drop `10bis`/`10ter`).
- New **step 14 — `_surface_check()`** with 4 aggregated sub-checks:
  - **A**: every `actions/workflows/X.yml` referenced in README exists on disk.
  - **B**: every `diplomat-gate[<extra>]` in README is declared in `pyproject.toml`.
  - **C**: every yaml block whose first 2 non-comment lines contain `version:`
    must `yaml.safe_load` cleanly (hero snippet without `version:` exempt;
    skipped gracefully if pyyaml absent).
  - **D**: every `<N>-step` mention in README must equal `TOTAL_STEPS`.
- `README.md`: `11-step` → `14-step` (×2) so Check D passes.

### Verified
Each of A/B/D triggered by deliberate local breaks (rename workflow,
inject bogus extra, swap step count); C exercised with pyyaml installed
and a corrupted versioned yaml block. All restored to PASS afterwards.

### Out of scope
No changes to `src/`, `tests/`, `benchmarks/`, or CI workflows.
Gate not run end-to-end (no release).